### PR TITLE
Set the sample rate as an attribute on the span

### DIFF
--- a/src/opentelemetry/ext/honeycomb/sampling/__init__.py
+++ b/src/opentelemetry/ext/honeycomb/sampling/__init__.py
@@ -27,9 +27,14 @@ class DeterministicSampler(Sampler):
         attributes: Attributes = None,
         links: Sequence["Link"] = (),
     ) -> "SamplingResult":
+        sample_rate = {'SampleRate': self.rate}
+        if attributes is None:
+           attributes = sample_rate
+        else:
+            attributes.update(sample_rate)
         sha1 = hashlib.sha1()
-        sha1.update(str(trace_id).encode('utf-8'))
+        sha1.update(hex(trace_id).encode('utf-8'))
         value, = struct.unpack('>I', sha1.digest()[:4])
         if value >= self.upper_bound:
-            return SamplingResult(Decision.DROP)
+            return SamplingResult(Decision.DROP, attributes)
         return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes)

--- a/src/opentelemetry/ext/honeycomb/sampling/version.py
+++ b/src/opentelemetry/ext/honeycomb/sampling/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.2b0'
+VERSION = '0.3b0'


### PR DESCRIPTION
We use sample rates to amplify spans when calculating aggregate functions.
Setting the sample rate as an attribute from the sampler allows us to send the
appropriate sample rate with the event payload. 